### PR TITLE
Fix main queue setup on ios

### DIFF
--- a/ios/Hce.m
+++ b/ios/Hce.m
@@ -6,4 +6,9 @@ RCT_EXTERN_METHOD(multiply:(float)a withB:(float)b
                  withResolver:(RCTPromiseResolveBlock)resolve
                  withRejecter:(RCTPromiseRejectBlock)reject)
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 @end


### PR DESCRIPTION
Hi,

I was getting this warning using the package on a react-native app, when running on ios:
```
Module Hce requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.
```

Looking into this issue on other packages, it seems like a simple fix. 

ℹ️ **Note** ESLint is not passing, but the errors are in files I did not change