### PR TITLE
Fix: update Kotlin version to 1.5.20 to support React Native

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-Hce_kotlinVersion=1.3.50
+Hce_kotlinVersion=1.5.20
 Hce_compileSdkVersion=28
 Hce_buildToolsVersion=28.0.3
 Hce_targetSdkVersion=28


### PR DESCRIPTION
## Problem 

`react-native-hce` hardcodes the kotlin version, which results in an error when trying to use gradle 7.x as it requires a minimum of 1.5.20. This blocks usage of this project on all new instances of React Native.

## What went wrong:

The Android Gradle plugin supports only Kotlin Gradle plugin version 1.5.20 and higher.
The following dependencies do not satisfy the required version:
project ':react-native-hce' -> org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50

## Solution

I've updated the minimum version of kotlin to 1.5.20. I've tested this change on new React Native application and works without issue.