### PR TITLE
Fix emulated Capability Container to achieve Android compatibility

### DIFF
--- a/android/src/main/java/com/reactnativehce/apps/nfc/NFCTagType4.java
+++ b/android/src/main/java/com/reactnativehce/apps/nfc/NFCTagType4.java
@@ -21,13 +21,13 @@ public class NFCTagType4 implements IHCEApplication {
   private static final byte[] C_APDU_SELECT = BinaryUtils.HexStringToByteArray("00A4040007D276000085010100");
   private static final byte[] FILENAME_CC = BinaryUtils.HexStringToByteArray("E103");
   private static final byte[] FILENAME_NDEF = BinaryUtils.HexStringToByteArray("E104");
-  private static final byte[] CC_HEADER = BinaryUtils.HexStringToByteArray("001120010000FF");
+  private static final byte[] CC_HEADER = BinaryUtils.HexStringToByteArray("000F20010000FF");
   private final PrefManager prefManager;
   private final HceViewModel hceModel;
 
   private SelectedFile selectedFile = null;
-  public final byte[] ndefDataBuffer = new byte[0x1000];
-  public final byte[] ccDataBuffer = new byte[15];
+  public final byte[] ndefDataBuffer = new byte[0x7FFF];
+  public final byte[] ccDataBuffer = new byte[0x000F];
 
   private enum SelectedFile {
     FILENAME_CC,
@@ -49,7 +49,7 @@ public class NFCTagType4 implements IHCEApplication {
 
   private void setUpCapabilityContainerContent() {
     System.arraycopy(CC_HEADER, 0, this.ccDataBuffer, 0, CC_HEADER.length);
-    byte[] controlTlv = BinaryUtils.HexStringToByteArray("0406E104100000" + (prefManager.getWritable() ? "00":"FF"));
+    byte[] controlTlv = BinaryUtils.HexStringToByteArray("0406E1047FFF00" + (prefManager.getWritable() ? "00":"FF"));
     System.arraycopy(controlTlv, 0, this.ccDataBuffer, CC_HEADER.length, controlTlv.length);
   }
 

--- a/android/src/main/java/com/reactnativehce/apps/nfc/NFCTagType4.java
+++ b/android/src/main/java/com/reactnativehce/apps/nfc/NFCTagType4.java
@@ -21,7 +21,7 @@ public class NFCTagType4 implements IHCEApplication {
   private static final byte[] C_APDU_SELECT = BinaryUtils.HexStringToByteArray("00A4040007D276000085010100");
   private static final byte[] FILENAME_CC = BinaryUtils.HexStringToByteArray("E103");
   private static final byte[] FILENAME_NDEF = BinaryUtils.HexStringToByteArray("E104");
-  private static final byte[] CC_HEADER = BinaryUtils.HexStringToByteArray("001120FFFFFFFF");
+  private static final byte[] CC_HEADER = BinaryUtils.HexStringToByteArray("001120010000FF");
   private final PrefManager prefManager;
   private final HceViewModel hceModel;
 
@@ -49,7 +49,7 @@ public class NFCTagType4 implements IHCEApplication {
 
   private void setUpCapabilityContainerContent() {
     System.arraycopy(CC_HEADER, 0, this.ccDataBuffer, 0, CC_HEADER.length);
-    byte[] controlTlv = BinaryUtils.HexStringToByteArray("0406E104FFFE00" + (prefManager.getWritable() ? "00":"FF"));
+    byte[] controlTlv = BinaryUtils.HexStringToByteArray("0406E104100000" + (prefManager.getWritable() ? "00":"FF"));
     System.arraycopy(controlTlv, 0, this.ccDataBuffer, CC_HEADER.length, controlTlv.length);
   }
 
@@ -108,7 +108,7 @@ public class NFCTagType4 implements IHCEApplication {
     System.arraycopy(ApduHelper.R_APDU_OK, 0, response, realLength, ApduHelper.R_APDU_OK.length);
 
     this.hceModel.getLastState()
-      .setValue(HceViewModel.HCE_STATE_READ);
+            .setValue(HceViewModel.HCE_STATE_READ);
 
     return response;
   }
@@ -143,12 +143,12 @@ public class NFCTagType4 implements IHCEApplication {
       this.prefManager.setContent(nm.getContent());
       this.prefManager.setType(nm.getType());
       this.hceModel.getLastState()
-        .setValue(HceViewModel.HCE_STATE_WRITE_FULL);
+              .setValue(HceViewModel.HCE_STATE_WRITE_FULL);
       this.hceModel.getLastState()
-        .setValue(HceViewModel.HCE_STATE_UPDATE_APPLICATION);
+              .setValue(HceViewModel.HCE_STATE_UPDATE_APPLICATION);
     } else {
       this.hceModel.getLastState()
-        .setValue(HceViewModel.HCE_STATE_WRITE_PARTIAL);
+              .setValue(HceViewModel.HCE_STATE_WRITE_PARTIAL);
     }
 
     return ApduHelper.R_APDU_OK;
@@ -175,6 +175,6 @@ public class NFCTagType4 implements IHCEApplication {
   @Override
   public void onDestroy(int reason) {
     this.hceModel.getLastState()
-      .setValue(HceViewModel.HCE_STATE_DISCONNECTED);
+            .setValue(HceViewModel.HCE_STATE_DISCONNECTED);
   }
 }

--- a/android/src/main/java/com/reactnativehce/apps/nfc/NFCTagType4.java
+++ b/android/src/main/java/com/reactnativehce/apps/nfc/NFCTagType4.java
@@ -108,7 +108,7 @@ public class NFCTagType4 implements IHCEApplication {
     System.arraycopy(ApduHelper.R_APDU_OK, 0, response, realLength, ApduHelper.R_APDU_OK.length);
 
     this.hceModel.getLastState()
-            .setValue(HceViewModel.HCE_STATE_READ);
+      .setValue(HceViewModel.HCE_STATE_READ);
 
     return response;
   }
@@ -143,12 +143,12 @@ public class NFCTagType4 implements IHCEApplication {
       this.prefManager.setContent(nm.getContent());
       this.prefManager.setType(nm.getType());
       this.hceModel.getLastState()
-              .setValue(HceViewModel.HCE_STATE_WRITE_FULL);
+        .setValue(HceViewModel.HCE_STATE_WRITE_FULL);
       this.hceModel.getLastState()
-              .setValue(HceViewModel.HCE_STATE_UPDATE_APPLICATION);
+        .setValue(HceViewModel.HCE_STATE_UPDATE_APPLICATION);
     } else {
       this.hceModel.getLastState()
-              .setValue(HceViewModel.HCE_STATE_WRITE_PARTIAL);
+        .setValue(HceViewModel.HCE_STATE_WRITE_PARTIAL);
     }
 
     return ApduHelper.R_APDU_OK;
@@ -175,6 +175,6 @@ public class NFCTagType4 implements IHCEApplication {
   @Override
   public void onDestroy(int reason) {
     this.hceModel.getLastState()
-            .setValue(HceViewModel.HCE_STATE_DISCONNECTED);
+      .setValue(HceViewModel.HCE_STATE_DISCONNECTED);
   }
 }

--- a/android/src/main/java/com/reactnativehce/apps/nfc/NFCTagType4.java
+++ b/android/src/main/java/com/reactnativehce/apps/nfc/NFCTagType4.java
@@ -26,7 +26,7 @@ public class NFCTagType4 implements IHCEApplication {
   private final HceViewModel hceModel;
 
   private SelectedFile selectedFile = null;
-  public final byte[] ndefDataBuffer = new byte[0xFFFE];
+  public final byte[] ndefDataBuffer = new byte[0x1000];
   public final byte[] ccDataBuffer = new byte[15];
 
   private enum SelectedFile {


### PR DESCRIPTION
Dzień dobry!

It seems like recent Android phone versions don't like the Capability Container values as they are currently emulated within this project.

This PR:

1. Adjusts the Capability Container to the correct size of 0x0F (resolve #37).
2. Lowers the values indicated by fields mentioned below in order to achieve greatest possible interoperability (resolve #38 resolve #35 resolve #31).
   * MLe (bytes); Maximum RAPDU data size
   * MLc (bytes); Maximum CAPDU data size
   * NDEF File Control TLV - Maximum NDEF file size

The current implementation doesn't work with Galaxy A55 on Android 15. I've verified that it starts running correctly after introducing changes covered by this PR. Also tested with iPhone 11 and iPhone 16.