### PR TITLE
fix(hce): Fixed false failure due to to multiple Select App APDU calls

### DIFF
--- a/android/src/main/java/com/reactnativehce/services/CardService.java
+++ b/android/src/main/java/com/reactnativehce/services/CardService.java
@@ -27,10 +27,6 @@ public class CardService extends HostApduService {
 
     @Override
     public byte[] processCommandApdu(byte[] command, Bundle extras) {
-      if (currentHCEApplication != null) {
-        return currentHCEApplication.processCommand(command);
-      }
-
       if (ApduHelper.commandByRangeEquals(command, 0, 4, ApduHelper.C_APDU_SELECT_APP)) {
         for (IHCEApplication app : registeredHCEApplications) {
           if (app.assertSelectCommand(command)) {
@@ -38,6 +34,8 @@ public class CardService extends HostApduService {
             return ApduHelper.R_APDU_OK;
           }
         }
+      } else if (currentHCEApplication != null) {
+        return currentHCEApplication.processCommand(command);
       }
 
       return ApduHelper.R_APDU_ERROR;


### PR DESCRIPTION
I encountered an issue with the `SELECT_APP APDU` command where the `processCommandApdu` is triggered twice. The first invocation returns `R_APDU_OK`, but the second invocation returns `R_APDU_ERROR`. This causes the first successful `SELECT_APP` response to be overwritten.

This issue is observed only when the HCE app interacts with iOS devices. I suspect it might be due to some changes with the latest Android version that causes this behaviour.

To resolve this, I have updated the sequence of when `currentHCEApplication.processCommand(command)` is called.

**Before**
<img width="300" alt="Image (5)" src="https://github.com/user-attachments/assets/873740b6-9703-4a07-9de5-c07fb4528f04" />

**After**
<img width="300" alt="Image (3)" src="https://github.com/user-attachments/assets/7e6a0664-86bf-4dde-9508-a566a3221ba4" />