### PR TITLE
chore: drop jcenter repository

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 
   dependencies {
@@ -52,7 +52,6 @@ android {
 
 repositories {
   mavenCentral()
-  jcenter()
   google()
 
   def found = false


### PR DESCRIPTION
Since v0.82.0, React Native migrated to Gradle v9.0
Gradle 9.0.0 dropped support of JCenter repository which was officially shut down by JFrog in May 2021 and has been read-only since March 31, 2021
This PR fixes this Android build error:
```
Build file '/Users/andy/Orb/app/node_modules/react-native-hce/android/build.gradle' line: 7

* What went wrong:
A problem occurred evaluating project ':react-native-hce'.
> Could not find method jcenter() for arguments [] on repository container of type org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler.
```