### PR TITLE
fix: drop obsolete JCenter repository

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 
   dependencies {
@@ -52,7 +52,6 @@ android {
 
 repositories {
   mavenCentral()
-  jcenter()
   google()
 
   def found = false


### PR DESCRIPTION
This PR serves as a "bump" to this other PR here: https://github.com/appidea/react-native-hce/pull/43

I see that the changes there have been accepted but the branch hasn't been merged, then the head branch was subsequently deleted so the PR was closed automatically.
I created this since I encountered the same issue of not being able to build my app (same error shown in the PR I linked above), the applied fix is the same.